### PR TITLE
Release 2.10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -67,7 +62,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -75,6 +69,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.9.1" %}
+{% set version = "2.10" %}
 
 package:
   name: glances
@@ -7,7 +7,7 @@ package:
 source:
   fn: Glances-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/G/Glances/Glances-{{ version }}.tar.gz
-  sha256: 03ce730566e183372ee73e45729485396bb62d1c0f108a00f27feff43206fc52
+  sha256: 3e3ebd41a4f627b76ee1cdf107482d81e787efde8a5e41e6568169d38eb2e696
 
 build:
   number: 0


### PR DESCRIPTION
```
Version 2.10
============

Enhancements and new features:

    * New plugin to scan remote Web sites (URL) (issue #981)
    * Add trends in the Curses interface (issue #1077)
    * Add new repeat function to the action (issue #952)
    * Use -> and <- arrows keys to switch between processing sort (issue #1075)
    * Refactor __init__ and main scripts (issue #1050)
    * [WebUI] Improve WebUI for Windows 10 (issue #1052)

Bugs corrected:

    * StatsD export prefix option is ignored (issue #1074)
    * Some FS and LAN metrics fail to export correctly to StatsD (issue #1068)
    * Problem with non breaking space in file system name (issue #1065)
    * TypeError: string indices must be integers (Network plugin) (issue #1054)
    * No Offline status for timeouted ports? (issue #1084)
    * When exporting, uptime values loop after 1 day (issue #1092)

Installation:

  * Create a package.sh script to generate .DEB, .RPM and others... (issue #722)
  ==> https://github.com/nicolargo/glancesautopkg
* OSX: can't python setup.py install due to python 3.5 constraint (issue #1064)
```