### PR TITLE
Release 2.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.10" %}
+{% set version = "2.11" %}
 
 package:
   name: glances
@@ -7,10 +7,10 @@ package:
 source:
   fn: Glances-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/G/Glances/Glances-{{ version }}.tar.gz
-  sha256: 3e3ebd41a4f627b76ee1cdf107482d81e787efde8a5e41e6568169d38eb2e696
+  sha256: 94c9d54c6d158492aed454918cca91103387e03170397ba8cc7e9328db8dc9a1
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:


### PR DESCRIPTION
```
Enhancements and new features:

* New export plugin: standard and configurable Restfull exporter (issue #1129)
* Add a JSON export module (issue #1130)
* [WIP] Refactoring of the WebUI

Bugs corrected:

* Installing GPU plugin crashes entire Glances (issue #1102)
* Potential memory leak in Windows WebUI (issue #1056)
* glances_network `OSError: [Errno 19] No such device` (issue #1106)
* GPU plugin. <class 'TypeError'>: ... not JSON serializable"> (issue #1112)
* PermissionError on macOS (issue #1120)
* Cant move up or down in glances --browser (issue #1113)
* Unable to give aliases to or hide network interfaces and disks (issue #1126)
* `UnicodeDecodeError` on mountpoints with non-breaking spaces (issue #1128)

Installation:

* Create a Snap of Glances (issue #1101)
```