### PR TITLE
Add glances-web and glances-gpu sub-packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ConorForgie @jakirkham
+* @ConorForgie @gabrielcnr @jakirkham

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About glances-feedstock
-=======================
+About glances-suite-feedstock
+=============================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/glances-feedstock/blob/main/LICENSE.txt)
 
@@ -27,27 +27,29 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-glances-green.svg)](https://anaconda.org/conda-forge/glances) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/glances.svg)](https://anaconda.org/conda-forge/glances) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/glances.svg)](https://anaconda.org/conda-forge/glances) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/glances.svg)](https://anaconda.org/conda-forge/glances) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-glances--gpu-green.svg)](https://anaconda.org/conda-forge/glances-gpu) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/glances-gpu.svg)](https://anaconda.org/conda-forge/glances-gpu) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/glances-gpu.svg)](https://anaconda.org/conda-forge/glances-gpu) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/glances-gpu.svg)](https://anaconda.org/conda-forge/glances-gpu) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-glances--web-green.svg)](https://anaconda.org/conda-forge/glances-web) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/glances-web.svg)](https://anaconda.org/conda-forge/glances-web) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/glances-web.svg)](https://anaconda.org/conda-forge/glances-web) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/glances-web.svg)](https://anaconda.org/conda-forge/glances-web) |
 
-Installing glances
-==================
+Installing glances-suite
+========================
 
-Installing `glances` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `glances-suite` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `glances` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `glances, glances-gpu, glances-web` can be installed with `conda`:
 
 ```
-conda install glances
+conda install glances glances-gpu glances-web
 ```
 
 or with `mamba`:
 
 ```
-mamba install glances
+mamba install glances glances-gpu glances-web
 ```
 
 It is possible to list all of the versions of `glances` available on your platform with `conda`:
@@ -117,17 +119,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating glances-feedstock
-==========================
+Updating glances-suite-feedstock
+================================
 
-If you would like to improve the glances recipe or build a new
+If you would like to improve the glances-suite recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/glances-feedstock are
+Note that all branches in the conda-forge/glances-suite-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
@@ -143,5 +145,6 @@ Feedstock Maintainers
 =====================
 
 * [@ConorForgie](https://github.com/ConorForgie/)
+* [@gabrielcnr](https://github.com/gabrielcnr/)
 * [@jakirkham](https://github.com/jakirkham/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set python_min = "3.10" %}
 
 package:
-  name: glances
+  name: glances-suite
   version: {{ version }}
 
 source:
@@ -12,37 +12,69 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  entry_points:
-    - glances = glances:main
 
-requirements:
-  host:
-    - python {{ python_min }}
-    - pip
-    - setuptools
+outputs:
+  - name: glances
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . -vv --no-deps
+      entry_points:
+        - glances = glances:main
+    requirements:
+      host:
+        - python {{ python_min }}
+        - pip
+        - setuptools
+      run:
+        - python >={{ python_min }}
+        - psutil >=5.6.7
+        - defusedxml
+        - packaging
+        - jinja2
+        - pyinstrument >=5.1.2
+        - shtab
+    test:
+      requires:
+        - pip
+        - python {{ python_min }}
+      imports:
+        - glances
+      commands:
+        - pip check
+        - glances --help
 
-  run:
-    - python >={{ python_min }}
-    - psutil >=5.6.7
-    - defusedxml
-    - packaging
-    - jinja2
-    - pyinstrument >=5.1.2
-    - shtab
+  - name: glances-web
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage('glances', exact=True) }}
+        - fastapi >=0.82.0
+        - python-jose >=3.3.0
+        - requests
+        - uvicorn
+    test:
+      requires:
+        - python {{ python_min }}
+      imports:
+        - glances
+      commands:
+        - python -c "import fastapi; import jose; import uvicorn"
 
-test:
-  requires:
-    - pip
-    - python {{ python_min }}
-
-  imports:
-    - glances
-
-  commands:
-    - pip check
-    - glances --help
+  - name: glances-gpu
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage('glances', exact=True) }}
+        - nvidia-ml-py
+    test:
+      requires:
+        - python {{ python_min }}
+      imports:
+        - glances
+      commands:
+        - python -c "import pynvml"
 
 about:
   home: https://github.com/nicolargo/glances

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
   - name: glances
     build:
       noarch: python
-      script: {{ PYTHON }} -m pip install . -vv --no-deps
+      script: python -m pip install . -vv --no-deps --no-build-isolation
       entry_points:
         - glances = glances:main
     requirements:


### PR DESCRIPTION
Convert single-output recipe to multi-output to expose upstream extras as installable conda packages:

- **glances** — base package (unchanged behavior, pip install --no-deps)
- **glances-web** — metapackage for the web UI: fastapi, python-jose, requests, uvicorn
- **glances-gpu** — metapackage for GPU monitoring: nvidia-ml-py

Uses `pin_subpackage('glances', exact=True)` so sub-packages stay version-locked. Both new outputs are `noarch: generic` (no build script, deps only).

@conda-forge-admin, please rerender